### PR TITLE
ci: use bun for deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,13 +19,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout your repository using git
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Install, build, and upload your site
-              uses: withastro/action@v1
+              uses: withastro/action@v2
               with:
-                  path: . # The root location of your Astro project inside the repository. (optional)
-                  node-version: 18 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)
-                  package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+                  package-manager: bun # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
     deploy:
         needs: build
@@ -36,4 +34,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v1
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
Uses bun for the deploy action rather than pnpm. Also updates various actions. Resolves #1.